### PR TITLE
fix(Database): 修复MySQL批量插入只能插入一条数据的Bug

### DIFF
--- a/.Net6版本/VOL.Core/Dapper/SqlDapper.cs
+++ b/.Net6版本/VOL.Core/Dapper/SqlDapper.cs
@@ -786,12 +786,10 @@ namespace VOL.Core.Dapper
                         {
                             LineTerminator = "\n",
                             TableName = tableName,
-                            CharacterSet = "UTF8"
+                            CharacterSet = "UTF8",
+                            FieldQuotationCharacter = '"',
+                            FieldQuotationOptional = true
                         };
-                        if (csv.IndexOf("\n")>0)
-                        {
-                            csv = csv.Replace("\n", " ");
-                        }
                         var array = Encoding.UTF8.GetBytes(csv);
                         using (stream = new MemoryStream(array))
                         {
@@ -833,9 +831,10 @@ namespace VOL.Core.Dapper
                 {
                     colum = table.Columns[i];
                     if (i != 0) sb.Append("\t");
-                    if (colum.DataType == typeString && row[colum].ToString().Contains(","))
+                    if (colum.DataType == typeString)
                     {
-                        sb.Append(row[colum].ToString());
+                        var data = $"\"{row[colum].ToString().Replace("\"", "\"\"")}\"";
+                        sb.Append(data);
                     }
                     else if (colum.DataType == typeDate)
                     {

--- a/Vue.Net/VOL.Core/Dapper/SqlDapper.cs
+++ b/Vue.Net/VOL.Core/Dapper/SqlDapper.cs
@@ -786,12 +786,10 @@ namespace VOL.Core.Dapper
                         {
                             LineTerminator = "\n",
                             TableName = tableName,
-                            CharacterSet = "UTF8"
+                            CharacterSet = "UTF8",
+                            FieldQuotationCharacter = '"',
+                            FieldQuotationOptional = true
                         };
-                        if (csv.IndexOf("\n")>0)
-                        {
-                            csv = csv.Replace("\n", " ");
-                        }
                         var array = Encoding.UTF8.GetBytes(csv);
                         using (stream = new MemoryStream(array))
                         {
@@ -833,9 +831,10 @@ namespace VOL.Core.Dapper
                 {
                     colum = table.Columns[i];
                     if (i != 0) sb.Append("\t");
-                    if (colum.DataType == typeString && row[colum].ToString().Contains(","))
+                    if (colum.DataType == typeString)
                     {
-                        sb.Append(row[colum].ToString());
+                        var data = $"\"{row[colum].ToString().Replace("\"", "\"\"")}\"";
+                        sb.Append(data);
                     }
                     else if (colum.DataType == typeDate)
                     {


### PR DESCRIPTION
转csv的时候使用引号包裹字符串。
批量插入时，显式声明使用双引号包裹字段值，并且忽略包裹字段的双引号。