### PR TITLE
Add修改为与Update一致，先设置默认值再进行实体的校验 Update ServiceBase.cs

### DIFF
--- a/.Net6版本/VOL.Core/BaseProvider/ServiceBase.cs
+++ b/.Net6版本/VOL.Core/BaseProvider/ServiceBase.cs
@@ -542,6 +542,9 @@ namespace VOL.Core.BaseProvider
 
             saveDataModel.DetailData = saveDataModel.DetailData?.Where(x => x.Count > 0).ToList();
             Type type = typeof(T);
+            // 修改为与Update一致，先设置默认值再进行实体的校验
+            UserInfo userInfo = UserContext.Current.UserInfo;
+            saveDataModel.SetDefaultVal(AppSetting.CreateMember, userInfo);
 
             string validReslut = type.ValidateDicInEntity(saveDataModel.MainData, true, UserIgnoreFields);
 
@@ -549,10 +552,7 @@ namespace VOL.Core.BaseProvider
 
             if (saveDataModel.MainData.Count == 0)
                 return Response.Error("保存的数据为空，请检查model是否配置正确!");
-
-            UserInfo userInfo = UserContext.Current.UserInfo;
-            saveDataModel.SetDefaultVal(AppSetting.CreateMember, userInfo);
-
+                
             PropertyInfo keyPro = type.GetKeyProperty();
             if (keyPro.PropertyType == typeof(Guid))
             {


### PR DESCRIPTION
主要原因为在进行多租户处理时在SetDefaultVal添加租户隔离字段的默认值赋值，如果该字段为必填字段，不先设置默认值再进行校验的话无法校验通过。