### PR TITLE
修复resetSearchForm对级联无法设置正确的值的问题

### DIFF
--- a/Vol.Vue3版本/src/components/basic/ViewGrid/methods.js
+++ b/Vol.Vue3版本/src/components/basic/ViewGrid/methods.js
@@ -471,11 +471,14 @@ let methods = {
           }
           if (
             data &&
-            data.length > 0 &&
-            !this.keyValueType.hasOwnProperty(x.field)
+            data.length > 0
           ) {
-            this.keyValueType[x.field] = data[0].key;
-            this.keyValueType[keyLeft + x.field] = x.type;
+            if (!this.keyValueType.hasOwnProperty(x.field)){
+              this.keyValueType[x.field] = data[0].key;
+            }
+            if (!this.keyValueType.hasOwnProperty(keyLeft + x.field)){
+              this.keyValueType[keyLeft + x.field] = x.type;
+            }
           }
         });
       });


### PR DESCRIPTION
由于没有更新 searchform的 keyValueType 映射，导致resetSearchForm调用时级联控件无法将值转换成对应的数组